### PR TITLE
Test for cdn.eeduelements.com

### DIFF
--- a/controls/hawaii-alaska-whaledisentanglement-org.rb
+++ b/controls/hawaii-alaska-whaledisentanglement-org.rb
@@ -7,7 +7,10 @@ control 'hawaii-alaska-whaledisentanglement-org' do
 
   describe inspec.http("https://hawaii-alaska.whaledisentanglement.org", max_redirects: 1) do
     its('status') { should eq(200) }
-    its('body') { should match('<h2 class="site-description">Hawaii and Alaska</h2>') }
+    its('body') { 
+      should match('<h2 class="site-description">Hawaii and Alaska</h2>')
+      should_not match('cdn.eeduelements.com')
+    }
   end
   describe inspec.http("http://hawaii-alaska.whaledisentanglement.org", max_redirects: 2) do
     its('status') { should eq(200) }

--- a/controls/media-whaledisentanglement-org.rb
+++ b/controls/media-whaledisentanglement-org.rb
@@ -7,7 +7,10 @@ control 'media-whaledisentanglement-org' do
 
   describe inspec.http("https://media.whaledisentanglement.org", max_redirects: 1) do
     its('status') { should eq(200) }
-    its('body') { should match('<h2 class="site-description">Media</h2>') } 
+    its('body') { 
+      should match('<h2 class="site-description">Media</h2>')
+      should_not match('cdn.eeduelements.com')
+    } 
   end
   describe inspec.http("http://media.whaledisentanglement.org", max_redirects: 2) do
     its('status') { should eq(200) }

--- a/controls/pacific-northwest-whaledisentanglement-org.rb
+++ b/controls/pacific-northwest-whaledisentanglement-org.rb
@@ -7,7 +7,10 @@ control 'pacific-northwest-whaledisentanglement-org' do
 
   describe inspec.http("https://pacific-northwest.whaledisentanglement.org", max_redirects: 1) do
     its('status') { should eq(200) }
-    its('body') { should match('<h2 class="site-description">Pacific Northwest</h2>') } 
+    its('body') { 
+      should match('<h2 class="site-description">Pacific Northwest</h2>')
+      should_not match('cdn.eeduelements.com')
+    } 
   end
   describe inspec.http("http://pacific-northwest.whaledisentanglement.org", max_redirects: 2) do
     its('status') { should eq(200) }

--- a/controls/west-coast-whaledisentanglement-org.rb
+++ b/controls/west-coast-whaledisentanglement-org.rb
@@ -7,7 +7,10 @@ control 'west-coast-whaledisentanglement-org' do
 
   describe inspec.http("https://west-coast.whaledisentanglement.org", max_redirects: 1) do
     its('status') { should eq(200) }
-    its('body') { should match('<h2 class="site-description">West Coast</h2>') } 
+    its('body') { 
+      should match('<h2 class="site-description">West Coast</h2>')
+      should_not match('cdn.eeduelements.com')
+     } 
   end
   describe inspec.http("http://west-coast.whaledisentanglement.org", max_redirects: 2) do
     its('status') { should eq(200) }


### PR DESCRIPTION
The WordPress sites started trying to connect to the
cdn.eeduelements.com. We are not sure why or how this happened. We
reinstalled the code from the habitat builder and it went away.

Signed-off-by: Lance Finfrock <lfinfrock@chef.io>