### PR TITLE
Wordpress site are timing out

### DIFF
--- a/controls/hawaii-alaska-whaledisentanglement-org.rb
+++ b/controls/hawaii-alaska-whaledisentanglement-org.rb
@@ -5,14 +5,14 @@ control 'hawaii-alaska-whaledisentanglement-org' do
   title 'Hawaii Alaska Whale Disentanglement site is verified'
   desc 'test that the hawaii-alaska.whaledisentanglement.org is working'
 
-  describe inspec.http("https://hawaii-alaska.whaledisentanglement.org", max_redirects: 1) do
+  describe inspec.http("https://hawaii-alaska.whaledisentanglement.org", max_redirects: 1, read_timeout: 90) do
     its('status') { should eq(200) }
     its('body') { 
       should match('<h2 class="site-description">Hawaii and Alaska</h2>')
       should_not match('cdn.eeduelements.com')
     }
   end
-  describe inspec.http("http://hawaii-alaska.whaledisentanglement.org", max_redirects: 2) do
+  describe inspec.http("http://hawaii-alaska.whaledisentanglement.org", max_redirects: 2, read_timeout: 90) do
     its('status') { should eq(200) }
     its('body') { should match('<h2 class="site-description">Hawaii and Alaska</h2>') } 
   end

--- a/controls/media-whaledisentanglement-org.rb
+++ b/controls/media-whaledisentanglement-org.rb
@@ -5,14 +5,14 @@ control 'media-whaledisentanglement-org' do
   title 'Media Whale Disentanglement site is verified'
   desc 'test that the media.whaledisentanglement.org is working'
 
-  describe inspec.http("https://media.whaledisentanglement.org", max_redirects: 1) do
+  describe inspec.http("https://media.whaledisentanglement.org", max_redirects: 1, read_timeout: 90) do
     its('status') { should eq(200) }
     its('body') { 
       should match('<h2 class="site-description">Media</h2>')
       should_not match('cdn.eeduelements.com')
     } 
   end
-  describe inspec.http("http://media.whaledisentanglement.org", max_redirects: 2) do
+  describe inspec.http("http://media.whaledisentanglement.org", max_redirects: 2, read_timeout: 90) do
     its('status') { should eq(200) }
     its('body') { should match('<h2 class="site-description">Media</h2>') } 
   end

--- a/controls/pacific-northwest-whaledisentanglement-org.rb
+++ b/controls/pacific-northwest-whaledisentanglement-org.rb
@@ -5,14 +5,14 @@ control 'pacific-northwest-whaledisentanglement-org' do
   title 'Pacific Northwest Whale Disentanglement site is verified'
   desc 'test that the pacific-northwest.whaledisentanglement.org is working'
 
-  describe inspec.http("https://pacific-northwest.whaledisentanglement.org", max_redirects: 1) do
+  describe inspec.http("https://pacific-northwest.whaledisentanglement.org", max_redirects: 1, read_timeout: 90) do
     its('status') { should eq(200) }
     its('body') { 
       should match('<h2 class="site-description">Pacific Northwest</h2>')
       should_not match('cdn.eeduelements.com')
     } 
   end
-  describe inspec.http("http://pacific-northwest.whaledisentanglement.org", max_redirects: 2) do
+  describe inspec.http("http://pacific-northwest.whaledisentanglement.org", max_redirects: 2, read_timeout: 90) do
     its('status') { should eq(200) }
     its('body') { should match('<h2 class="site-description">Pacific Northwest</h2>') } 
   end

--- a/controls/west-coast-whaledisentanglement-org.rb
+++ b/controls/west-coast-whaledisentanglement-org.rb
@@ -5,14 +5,14 @@ control 'west-coast-whaledisentanglement-org' do
   title 'West Coast Whale Disentanglement site is verified'
   desc 'test that the west-coast.whaledisentanglement.org is working'
 
-  describe inspec.http("https://west-coast.whaledisentanglement.org", max_redirects: 1) do
+  describe inspec.http("https://west-coast.whaledisentanglement.org", max_redirects: 1, read_timeout: 90) do
     its('status') { should eq(200) }
     its('body') { 
       should match('<h2 class="site-description">West Coast</h2>')
       should_not match('cdn.eeduelements.com')
      } 
   end
-  describe inspec.http("http://west-coast.whaledisentanglement.org", max_redirects: 2) do
+  describe inspec.http("http://west-coast.whaledisentanglement.org", max_redirects: 2, read_timeout: 90) do
     its('status') { should eq(200) }
     its('body') { should match('<h2 class="site-description">West Coast</h2>') } 
   end


### PR DESCRIPTION
Increased the read time for all the wordpress sites because they were
timing out.

Signed-off-by: Lance Finfrock <lfinfrock@chef.io>